### PR TITLE
Fix IPC socket deleted on multi-output setups

### DIFF
--- a/src/ipc/ipc.cpp
+++ b/src/ipc/ipc.cpp
@@ -54,19 +54,7 @@ class ipc_t : public wf::per_output_plugin_instance_t
 
     void fini() override
     {
-        /* Notify exit */
-        signal_shutdown_event();
-
         unbind_events();
-
-        // Set a timeout of 100 ms to give some time to all clients to handle the
-        // "exit" signal before disconnecting them and finish this instance of plugin
-        display_destroy.notify = handle_display_destroy;
-        wl_display_add_destroy_listener(wf::get_core().display, &display_destroy);
-        fini_event_source =
-            wl_event_loop_add_timer(wf::get_core().ev_loop, handle_fini_timeout,
-                this);
-        wl_event_source_timer_update(fini_event_source, 100);
     }
 
     void fini_timeout() const

--- a/src/ipc/server/i3-ipc-server.cpp
+++ b/src/ipc/server/i3-ipc-server.cpp
@@ -59,6 +59,11 @@ uint32_t i3_ipc_server::client_count()
 
 void i3_ipc_server::serve() const
 {
+    if (ipc_socket > 0)
+    {
+        return;
+    }
+
     ipc_socket = -1;
     ipc_event_source = nullptr;
 
@@ -229,6 +234,7 @@ void i3_ipc_server::handle_display_destroy(struct wl_listener *listener, void *d
 
     close(ipc_socket);
     unlink(ipc_sockaddr.sun_path);
+    ipc_socket = 0;
 
     while (ipc_client_list.size())
     {


### PR DESCRIPTION
The i3-ipc plugin extends per_output_plugin_instance_t, so one instance is created per output. This caused two issues:

1. serve() was called once per output, each call unlinking the previous socket file before creating a new one. With N outputs, the socket was created and deleted N times.

2. When an output was disabled/removed, fini() triggered handle_display_destroy() which closed and unlinked the socket, even though other output instances still needed it.

Fix serve() to only initialize the socket once (guard on ipc_socket > 0), and simplify fini() to only unbind events without destroying the server. The server cleanup on actual shutdown is already handled by the wl_display_add_destroy_listener registered in serve().